### PR TITLE
Redirecting User to homepage if User tries to access login page even after logging in

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,3 +5,4 @@ Go Get Your Name Added:
 <a href="https://github.com/me-abhinav-1001"><sub><b>Abhinav Anand</b></sub></a>
 <a href="https://github.com/ashish923"><sub><b>Ashish Prasad Thakur</b></sub></a>
 <a href="https://github.com/JainendraDwivedi"><sub><b>Jainendra Dwivedi</b></sub></a>
+<a href="https://github.com/DNA5769"><sub><b>Dennis Thomas</b></sub></a>

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const path = require("path");
 const expressLayout = require("express-ejs-layouts");
 const bodyParser = require("body-parser");
 const cookie = require("cookie-parser");
+const redirectToHomeIfLoggedIn = require("./middleware/redirectToHomeIfLoggedIn");
 
 connectToMongo();
 
@@ -26,7 +27,7 @@ app.use("/api/notes", require("./routes/notes"));
 
 //Routes
 
-app.get("/login", (req, res) => {
+app.get("/login", redirectToHomeIfLoggedIn, (req, res) => {
   res.render("login");
 });
 

--- a/middleware/redirectToHomeIfLoggedIn.js
+++ b/middleware/redirectToHomeIfLoggedIn.js
@@ -1,0 +1,22 @@
+const jwt = require("jsonwebtoken");
+const dotenv = require("dotenv");
+
+dotenv.config({ path: "./.env" });
+
+const redirectToHomeIfLoggedIn = (req, res, next) => {
+  //Get user details from the jwt-token and add id to req object(body)
+  const token = req.cookies["auth-token"];
+  if (!token) {
+    return res.redirect("/login");
+  }
+  
+  // Checking if we are able to get user details, this means that user is already logged in
+  try {
+    const data = jwt.verify(token, process.env.JWT_SECRET);
+    return res.redirect("/api/auth/console"); // So we redirect the user to home
+  } catch (err) {
+    next(); // Else we just continue to the requested page
+  }
+};
+
+module.exports = redirectToHomeIfLoggedIn;


### PR DESCRIPTION
Fixes #5 

I first created a new middleware, `redirectToHomeIfLoggedIn()` which checks if user is logged in already, if it is it redirects user to homepage otherwise it just calls `next()` to proceed to requested route
`middleware/redirectToHomeIfLoggedIn.js`
```js
const redirectToHomeIfLoggedIn = (req, res, next) => {
  //Get user details from the jwt-token and add id to req object(body)
  const token = req.cookies["auth-token"];
  if (!token) {
    return res.redirect("/login");
  }

  // Checking if we are able to get user details, this means that user is already logged in
  try {
    const data = jwt.verify(token, process.env.JWT_SECRET);
    return res.redirect("/api/auth/console"); // So we redirect the user to home
  } catch (err) {
    next(); // Else we just continue to the requested page
  }
};
```

I then added this middleware to the login page i.e `/login` route
`index.js`
```js
app.get("/login", redirectToHomeIfLoggedIn, (req, res) => {
  res.render("login");
});
```